### PR TITLE
Add fdr.cutoff param in plotTreeTest functions

### DIFF
--- a/R/tree_plots.R
+++ b/R/tree_plots.R
@@ -7,6 +7,8 @@
 #' @param mid mid color on gradient
 #' @param high high color on gradient
 #' @param xmax.scale expand the x-axis by this factor so leaf labels fit in the plot
+#' @param fdr.cutoff A `numeric(1)` value used as the FDR cutoff for significance
+#' annotation. Defaults to 0.05.
 #'
 #' @return ggplot2 object
 #' @examples
@@ -28,13 +30,16 @@
 #'
 #' # Plot hierarchy and testing results
 #' plotTreeTest(res)
+#' 
+#' # Use FDR < 0.1 as signif cutoff
+#' plotTreeTest(res, fdr.cutoff = 0.1)
 #'
 #' # Extract results for first 3 nodes
 #' res[1:3, ]
 #' @importFrom ggtree ggtree geom_tiplab geom_point2 geom_text2 get_taxa_name
 #' @importFrom ggplot2 scale_size_area theme element_text scale_color_gradient2
 #' @export
-plotTreeTest <- function(tree, low = "grey90", mid = "red", high = "darkred", xmax.scale = 1.5) {
+plotTreeTest <- function(tree, low = "grey90", mid = "red", high = "darkred", xmax.scale = 1.5, fdr.cutoff = 0.05) {
   # PASS R check
   isTip <- label <- node <- FDR <- NULL
 
@@ -43,7 +48,7 @@ plotTreeTest <- function(tree, low = "grey90", mid = "red", high = "darkred", xm
     geom_point2(aes(label = node, color = pmin(4, -log10(FDR)), size = pmin(4, -log10(FDR)))) +
     scale_color_gradient2(name = bquote(-log[10] ~ FDR), limits = c(0, 4), low = low, mid = mid, high = high, midpoint = -log10(0.01)) +
     scale_size_area(name = bquote(-log[10] ~ FDR), limits = c(0, 4)) +
-    geom_text2(aes(label = "+", subset = FDR < 0.05), color = "white", size = 6, vjust = .3, hjust = .5) +
+    geom_text2(aes(label = "+", subset = FDR < fdr.cutoff), color = "white", size = 6, vjust = .3, hjust = .5) +
     theme(legend.position = "bottom", plot.title = element_text(hjust = 0.5))
 
   # get default max value of x-axis
@@ -65,6 +70,8 @@ plotTreeTest <- function(tree, low = "grey90", mid = "red", high = "darkred", xm
 #' @param high high color on gradient
 #' @param xmax.scale expand the x-axis by this factor so leaf labels fit in the plot
 #'
+#' @inheritParams plotTreeTest
+#'
 #' @return ggplot2 object
 #' @examples
 #' library(variancePartition)
@@ -83,10 +90,14 @@ plotTreeTest <- function(tree, low = "grey90", mid = "red", high = "darkred", xm
 #' # Perform multivariate test across the hierarchy
 #' res <- treeTest(fit, cobj, hcl, coef = "StimStatusstim")
 #'
-#' # Plot hierarchy, no tests are significant
+#' # Plot hierarchy, no tests are significant at FDR < 0.05
 #' plotTreeTestBeta(res)
+#' 
+#' # Use FDR < 0.1 as signif cutoff
+#' plotTreeTestBeta(res, fdr.cutoff = 0.1)
+#' 
 #' @export
-plotTreeTestBeta <- function(tree, low = "blue", mid = "white", high = "red", xmax.scale = 1.5) {
+plotTreeTestBeta <- function(tree, low = "blue", mid = "white", high = "red", xmax.scale = 1.5, fdr.cutoff = 0.05) {
   # PASS R check
   isTip <- label <- node <- FDR <- NULL
 
@@ -106,7 +117,7 @@ plotTreeTestBeta <- function(tree, low = "blue", mid = "white", high = "red", xm
     geom_point2(aes(label = node, color = beta, size = pmin(4, -log10(FDR)))) +
     scale_color_gradient2(name = bquote(beta), low = low, mid = mid, high = high, midpoint = 0, limits = c(-beta_max, beta_max)) +
     scale_size_area(name = bquote(-log[10] ~ FDR), limits = c(0, 4)) +
-    geom_text2(aes(label = "+", subset = FDR < 0.05), color = "white", size = 6, vjust = .3, hjust = .5) +
+    geom_text2(aes(label = "+", subset = FDR < fdr.cutoff), color = "white", size = 6, vjust = .3, hjust = .5) +
     theme(legend.position = "bottom", plot.title = element_text(hjust = 0.5))
 
   # get default max value of x-axis

--- a/man/plotTreeTest.Rd
+++ b/man/plotTreeTest.Rd
@@ -9,7 +9,8 @@ plotTreeTest(
   low = "grey90",
   mid = "red",
   high = "darkred",
-  xmax.scale = 1.5
+  xmax.scale = 1.5,
+  fdr.cutoff = 0.05
 )
 }
 \arguments{
@@ -22,6 +23,9 @@ plotTreeTest(
 \item{high}{high color on gradient}
 
 \item{xmax.scale}{expand the x-axis by this factor so leaf labels fit in the plot}
+
+\item{fdr.cutoff}{A `numeric(1)` value used as the FDR cutoff for significance
+annotation. Defaults to 0.05.}
 }
 \value{
 ggplot2 object
@@ -48,6 +52,9 @@ res <- treeTest(fit, cobj, hcl, coef = "StimStatusstim")
 
 # Plot hierarchy and testing results
 plotTreeTest(res)
+
+# Use FDR < 0.1 as signif cutoff
+plotTreeTest(res, fdr.cutoff = 0.1)
 
 # Extract results for first 3 nodes
 res[1:3, ]

--- a/man/plotTreeTestBeta.Rd
+++ b/man/plotTreeTestBeta.Rd
@@ -9,7 +9,8 @@ plotTreeTestBeta(
   low = "blue",
   mid = "white",
   high = "red",
-  xmax.scale = 1.5
+  xmax.scale = 1.5,
+  fdr.cutoff = 0.05
 )
 }
 \arguments{
@@ -22,6 +23,9 @@ plotTreeTestBeta(
 \item{high}{high color on gradient}
 
 \item{xmax.scale}{expand the x-axis by this factor so leaf labels fit in the plot}
+
+\item{fdr.cutoff}{A `numeric(1)` value used as the FDR cutoff for significance
+annotation. Defaults to 0.05.}
 }
 \value{
 ggplot2 object
@@ -46,6 +50,10 @@ fit <- eBayes(fit)
 # Perform multivariate test across the hierarchy
 res <- treeTest(fit, cobj, hcl, coef = "StimStatusstim")
 
-# Plot hierarchy, no tests are significant
+# Plot hierarchy, no tests are significant at FDR < 0.05
 plotTreeTestBeta(res)
+
+# Use FDR < 0.1 as signif cutoff
+plotTreeTestBeta(res, fdr.cutoff = 0.1)
+
 }


### PR DESCRIPTION
Hi Gabriel, 
I have found the crumblr package very useful, thanks for the great work! 
I think it would be quite useful to add a flexible FDR cutoff to the treeTest plotting functions, allowing flexibility in adding the significance annotations to the tree plots.
I have done so in this pull request.
Best!
-Louise 